### PR TITLE
Do not use a deprecated glfw callback by default

### DIFF
--- a/low-level.lisp
+++ b/low-level.lisp
@@ -452,7 +452,7 @@
 (defglfwcallback mouse-entered :void ((window :pointer) (entered :bool)))
 (defglfwcallback mouse-scrolled :void ((window :pointer) (xoffset :double) (yoffset :double)))
 (defglfwcallback key-changed :void ((window :pointer) (key key) (scan-code :int) (action key-state) (modifiers modifier)))
-(defglfwcallback char-entered :void ((window :pointer) (code-point :uint) (modifiers modifier)))
+(defglfwcallback char-entered :void ((window :pointer) (code-point :uint)))
 
 (defgeneric file-dropped (window paths))
 (cffi:defcallback file-dropped :void ((window :pointer) (path-count :int) (paths :pointer))
@@ -606,7 +606,7 @@
 (defglfwfun "glfwSetWindowContentScaleCallback" :pointer ((window :pointer) (callback :pointer)))
 (defglfwfun "glfwSetKeyCallback" :pointer ((window :pointer) (callback :pointer)))
 (defglfwfun "glfwSetCharCallback" :pointer ((window :pointer) (callback :pointer)))
-(defglfwfun "glfwSetCharModsCallback" :pointer ((window :pointer) (callback :pointer)))
+(defglfwfun "glfwSetCharModsCallback" :pointer ((window :pointer) (callback :pointer))) ;; DEPRECATED: upstream deprecation https://www.glfw.org/docs/3.3/deprecated.html
 (defglfwfun "glfwSetMouseButtonCallback" :pointer ((window :pointer) (callback :pointer)))
 (defglfwfun "glfwSetCursorPosCallback" :pointer ((window :pointer) (callback :pointer)))
 (defglfwfun "glfwSetCursorEnterCallback" :pointer ((window :pointer) (callback :pointer)))

--- a/wrapper.lisp
+++ b/wrapper.lisp
@@ -316,7 +316,7 @@
     (glfw:set-framebuffer-size-callback pointer (cffi:callback glfw:framebuffer-resized))
     (glfw:set-window-content-scale-callback pointer (cffi:callback glfw:window-content-scale-changed))
     (glfw:set-key-callback pointer (cffi:callback glfw:key-changed))
-    (glfw:set-char-mods-callback pointer (cffi:callback glfw:char-entered))
+    (glfw:set-char-callback pointer (cffi:callback glfw:char-entered))
     (glfw:set-mouse-button-callback pointer (cffi:callback glfw:mouse-button-changed))
     (glfw:set-cursor-pos-callback pointer (cffi:callback glfw:mouse-moved))
     (glfw:set-cursor-enter-callback pointer (cffi:callback glfw:mouse-entered))
@@ -361,7 +361,7 @@
 (defmethod mouse-entered ((window window) entered))
 (defmethod mouse-scrolled ((window window) xoffset yoffset))
 (defmethod key-changed ((window window) key scan-code action modifiers))
-(defmethod char-entered ((window window) code-point modifiers))
+(defmethod char-entered ((window window) code-point))
 (defmethod file-dropped ((window window) paths))
 
 (defmethod should-close-p ((window window))


### PR DESCRIPTION
Char+mod callback/function from glfw side is deprecated:
https://www.glfw.org/docs/3.3/deprecated.html