### PR TITLE
Fix Makefile to work on macOS

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -34,4 +34,4 @@ all:
 	mkdir -p build ../static
 	cmake -B build/ -DCMAKE_BUILD_TYPE=ReleaseWithDebug -DBUILD_SHARED_LIBS=ON -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF -DCMAKE_C_FLAGS="$(CFLAGS)" $(CMAKEFLAGS)
 	$(MAKE) -C build
-	cp build/src/*glfw*.$(EXT) ../static/libglfw-$(OS)-$(ARCH).$(EXT)
+	cp build/src/*glfw.$(EXT) ../static/libglfw-$(OS)-$(ARCH).$(EXT)


### PR DESCRIPTION
On macOS, the glob at the end of the `Makefile` failed with the beauty
```
cp build/src/*glfw*.dylib ../static/libglfw-mac-amd64.dylib
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
make: *** [Makefile:37: all] Error 64
```
because it matched three files:
```
-rwxr-xr-x build/src/libglfw.3.4.dylib
lrwxr-xr-x build/src/libglfw.3.dylib -> libglfw.3.4.dylib
lrwxr-xr-x build/src/libglfw.dylib -> libglfw.3.dylib
```

This fix works on macOS and Linux.
Not tested on Windows.