### PR TITLE
new-time and last-time should be quoting symbols

### DIFF
--- a/wrapper.lisp
+++ b/wrapper.lisp
@@ -703,7 +703,7 @@
                     do (poll-events)
                        (let* ((,window ,window)
                               (,new-time (timestamp))
-                              (,dt (* (- new-time last-time) ,time-resolution)))
+                              (,dt (* (- ,new-time ,last-time) ,time-resolution)))
                          (declare (type (unsigned-byte 64) ,new-time))
                          (setf ,last-time ,new-time)
                          ,@body)


### PR DESCRIPTION
The with-game-loop macro is crashing due to undefined variables which should've been referencing the gensym'd symbols.